### PR TITLE
feat: Cleaning login field for whitespaces and length required

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -14,7 +14,8 @@
   "fields": {
     "login": {
       "type": "text",
-      "max": 7
+      "min": 13,
+      "max": 13
     },
     "password": {
       "type": "password"

--- a/src/index.js
+++ b/src/index.js
@@ -323,9 +323,15 @@ function daysInMonth(month, year) {
 }
 
 function normalizeLogin(login) {
-  if (login && login.length < 7 && login.padStart) {
-    log('info', 'Had to normalize login length to 7 chars')
-    return login.padStart(7, '0')
+  log('debug', 'normalizeLogin start')
+  if (login && login.length > 13) {
+    log('info', 'Had to normalize login length to 13 chars')
+    const normalizedLogin = login.replace(/\s/g, '').slice(0, 13)
+    return normalizedLogin
+  }
+  if (login && login.length < 13) {
+    log('info', 'Login length is under 13 characters')
+    throw new Error(errors.LOGIN_FAILED)
   }
 
   return login


### PR DESCRIPTION
Sometimes user's input for login contains whitespaces or is too long.
This cleans the login before trying to log in.