### PR TITLE
fix: Fix condition for user_action_needed.cgu_form 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -156,9 +156,10 @@ async function authenticate(login, password) {
       contexteAppel: 'caffr'
     }
   })
-
-  if (authResp.cguAValider === true) {
-    throw new Error('USER_ACTION_NEEDED.CGU_FORM')
+  for (const etape of authResp.etapesConnexion) {
+    if (etape.nom === 'CGU' && etape.obligatoire === true) {
+      throw new Error('USER_ACTION_NEEDED.CGU_FORM')
+    }
   }
 
   // Get LtpaToken2 with ccode


### PR DESCRIPTION
This PR aim to fix the error thrown by the konnector when CAF website is asking for a CGU validation to the user after the login.