### PR TITLE
[SCR-289] fix: Fix phone fetching when no phone provide

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -436,7 +436,7 @@ function findPhoneNumbers(receivedCoordinates) {
     receivedCoordinates.numTel2
   ]
   for (const number of foundNumbers) {
-    if (number === 'A communiquer') {
+    if (!number || number === 'A communiquer') {
       continue
     }
     const isMobile = ['06', '07', '+336', '+337'].some(digit =>


### PR DESCRIPTION
Do not fail when the first and second phone are not defined.