### PR TITLE
[SCR-982] feat: Detect 2FA and remove rememberMe checkBox

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -76,6 +76,12 @@ class CafContentScript extends ContentScript {
     const passwordField = document.querySelector('#inputMotDePasse')
     if (loginField && passwordField) {
       this.log('info', 'Found credentials fields, adding form listener')
+      // Hidding remember-me checkbox to avoid obfusquated login values
+      // It was causing issues with the autofill, leading to save and apply login formed like "123456789XXX" after first login
+      document.querySelector(
+        'label[for="souvenir"]'
+      ).parentElement.style.opacity = '0'
+      this.log('info', 'Removed rememberMe checkbox')
       const loginForm = document.querySelector('form')
       loginForm.addEventListener('submit', () => {
         const login = loginField.value
@@ -161,6 +167,10 @@ class CafContentScript extends ContentScript {
     if (document.querySelector('cnaf-cds-profilcomplet-profil-primo')) {
       await this.sendToPilot({ isInactive: true })
       return true
+    }
+    if (document.querySelector('app-mfa')) {
+      this.log('info', 'Waiting for user to complete 2FA ...')
+      return false
     }
     return Boolean(document.querySelector('#paiements-droits-collapse'))
   }
@@ -513,7 +523,9 @@ class CafContentScript extends ContentScript {
 
 const connector = new CafContentScript({ requestInterceptor })
 connector
-  .init({ additionalExposedMethodsNames: ['checkCaptcha', 'getFileDataUri'] })
+  .init({
+    additionalExposedMethodsNames: ['checkCaptcha', 'getFileDataUri']
+  })
   .catch(err => {
     log.warn(err)
   })


### PR DESCRIPTION
Website adds 2FA on every connections, it was already kind of supported by side effect, as we were showing to the user the login page everytime already and the konnector was waiting to detect the connected homePage, but now it's detected and if something  is wrong we will be able to know its with the 2FA.

On the other hand, we hide the rememberMe checkBox as it was causing issues with the saved credentials or when applying it on a new connection. the login was partialy obfusquated (like 123456789XXX) leading all connections after the first to show this obfusquated login when reaching loginPage (as prefill). Because of this, when credential was intercepted again, we were saving this prefilled login, therefore saving the obfusquated login instead of the full (right) one, breaking our prefill on following execution.